### PR TITLE
Add setup for Hotjar

### DIFF
--- a/docs/mint.config.json
+++ b/docs/mint.config.json
@@ -83,5 +83,11 @@
   ],
   "footerSocials": {
     "website": "https://www.usebracket.com"
+  },
+  "analytics": {
+    "hotjar": {
+      "hjid": "INSERT_HJID",
+      "hjsv": "INSERT_HJSV"
+    }
   }
 }


### PR DESCRIPTION
# Summary

This PR adds the setup for Hotjar analytics. It's really important to add the `hjid` and `hjsv` values into the config file. You can learn more about how to get the id values at their [HelpDocs](https://help.hotjar.com/hc/en-us/articles/360019646533-HelpDocs#:~:text=You%20can%20find%20your%20Hotjar,the%20HelpDocs%20installation%20pop%2Dup.)